### PR TITLE
Update repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/joachimvh/asyncjoin.js"
+    "url": "https://github.com/comunica/asyncjoin"
   },
   "dependencies": {
     "asynciterator": "^3.2.0"


### PR DESCRIPTION
Just went to look up this repo from https://www.npmjs.com/package/asyncjoin and saw it had moved, so here's an update PR for you!