### PR TITLE
Replace tail recursion with while loop in HashJoin.

### DIFF
--- a/join/HashJoin.js
+++ b/join/HashJoin.js
@@ -60,40 +60,39 @@ class HashJoin extends AsyncIterator
 
     read ()
     {
-        if (!this.addedDataListener)
-        {
-            this.addedDataListener = true;
-            this._addDataListener();
+        while(true) {
+            if (!this.addedDataListener)
+            {
+                this.addedDataListener = true;
+                this._addDataListener();
+            }
+
+            if (this.ended || !this.readable)
+                return null;
+
+            while (this.matchIdx < this.matches.length)
+            {
+                let item = this.matches[this.matchIdx++];
+                let result = this.funJoin(item, this.match);
+                if (result !== null)
+                    return result;
+            }
+
+            if (!this.hasResults())
+                this._end();
+
+            this.match = this.right.read();
+
+            if (this.match === null)
+            {
+                this.readable = false;
+                return null;
+            }
+
+            let hash = this.funHash(this.match);
+            this.matches = this.leftMap.get(hash) || [];
+            this.matchIdx = 0;
         }
-
-        if (this.ended || !this.readable)
-            return null;
-
-        while (this.matchIdx < this.matches.length)
-        {
-            let item = this.matches[this.matchIdx++];
-            let result = this.funJoin(item, this.match);
-            if (result !== null)
-                return result;
-        }
-
-        if (!this.hasResults())
-            this._end();
-
-        this.match = this.right.read();
-
-        if (this.match === null)
-        {
-            this.readable = false;
-            return null;
-        }
-
-        let hash = this.funHash(this.match);
-        this.matches = this.leftMap.get(hash) || [];
-        this.matchIdx = 0;
-
-        // array is filled again so recursive call can have results
-        return this.read();
     }
 
     _addDataListener()

--- a/join/HashJoin.js
+++ b/join/HashJoin.js
@@ -60,13 +60,13 @@ class HashJoin extends AsyncIterator
 
     read ()
     {
-        while(true) {
-            if (!this.addedDataListener)
-            {
-                this.addedDataListener = true;
-                this._addDataListener();
-            }
+        if (!this.addedDataListener)
+        {
+            this.addedDataListener = true;
+            this._addDataListener();
+        }
 
+        while(true) {
             if (this.ended || !this.readable)
                 return null;
 


### PR DESCRIPTION
The tail recursion in this function resulted in a large call stack, resulting in a RangeError